### PR TITLE
Lab4 Doc

### DIFF
--- a/_labs/lab04.markdown
+++ b/_labs/lab04.markdown
@@ -33,9 +33,10 @@ The `delta` tool performs delta debugging to shrink a program input. To help gen
 /cis547vm/lab4/test$ rm -rf fuzz_output && mkdir fuzz_output
 /cis547vm/lab4/test$ timeout 1 ../build/fuzzer ./fuzz0 fuzz_input
 fuzz_output
+/cis547vm/lab4/test$ ../build/delta ./fuzz0 fuzz_output/failure/input1
 ```
 
-The last argument (`fuzz_output/failure/input1`) is subject to change depending on what files are available in the `fuzz_output/failure` directory. The reduced input is stored in `fuzz_output/failure/input1.delta`. Additionally, before running another invocation of `../build/delta`, make sure to clean up the `fuzz_output` directory. You can do this by running `rm -rf fuzz_putput && mkdir fuzz_output`.
+The last argument (`fuzz_output/failure/input1`) is subject to change depending on what files are available in the `fuzz_output/failure` directory. The reduced input is stored in `fuzz_output/failure/input1.delta`. Additionally, before running another invocation of `../build/delta`, make sure to clean up the `fuzz_output` directory. You can do this by running `rm -rf fuzz_output && mkdir fuzz_output`.
 
 ### Lab Instructions
 

--- a/_labs/lab04.markdown
+++ b/_labs/lab04.markdown
@@ -1,0 +1,10 @@
+---
+layout: lab
+_id: "4"
+title: "Delta"
+synopsis: |
+  Building a coverage-guided random input generator a.k.a. “fuzzer” for testing C programs.
+---
+
+### Objective
+Foo-bar

--- a/_labs/lab04.markdown
+++ b/_labs/lab04.markdown
@@ -45,14 +45,14 @@ To build and install the package, run:
 Unlike with `c++`, you *won't* need to re-run this command
 after making changes to your code.
 Further, you will be able to use your delta debugger using the
-`delta-debugger` command from the terminal.
+`delta_debugger` command from the terminal.
 
-The `delta-debugger` tool performs delta debugging to shrink
+The `delta_debugger` tool performs delta debugging to shrink
 a crashing input to a program.
 
 ##### Step 2.
 
-To use `delta-debugger` with a program you first need to find some input
+To use `delta_debugger` with a program you first need to find some input
 that will crash the program.
 To find such an input we will use a fuzzer.
 
@@ -92,18 +92,18 @@ fuzz_output_sanity1
     └── inputN
 ```
 
-You can now use `delta-debugger` to minimize the crashing
+You can now use `delta_debugger` to minimize the crashing
 inputs found by the fuzzer.
 
 ```
 /lab4/test$ delta-debugger ./sanity1 fuzz_output_sanity1/failure/input1
 ```
 
-The last argument (`fuzz_output/failure/input1`) is subject to change depending on what files are available in the `fuzz_output/failure` directory. The reduced input is stored in `fuzz_output/failure/input1.delta`. Additionally, before running another invocation of `../build/delta`, make sure to clean up the `fuzz_output` directory. You can do this by running `rm -rf fuzz_output && mkdir fuzz_output`.
+The last argument (`fuzz_output/failure/input1`) is subject to change depending on what files are available in the `fuzz_output/failure` directory. The reduced input is stored in `fuzz_output/failure/input1.delta`. Additionally, before running another invocation of `delta_debugger`, make sure to clean up the `fuzz_output` directory. You can do this by running `rm -rf fuzz_output && mkdir fuzz_output`.
 
 ### Lab Instructions
 
-You will need to edit the `lab4/src/Delta.cpp` file to build a delta debugging tool. We have provided a template function - `delta` - for you to implement your minimization logic. `delta` should take a `Target` input program, and an `Input` bytestring that causes the Target program to crash, and find a 1-minimal input that still crashes the input program.
+You will need to edit the `lab4/src/delta.py` file to build a delta debugging tool. We have provided a template function - `delta` - for you to implement your minimization logic. `delta` should take a `Target` input program, and an `Input` bytestring that causes the Target program to crash, and find a 1-minimal input that still crashes the input program.
 
 To perform delta debugging, you will have to repeatedly run the target input with various input strings. The skeleton code provides a couple of auxiliary functions in `lab4/include/Utils.h` to help you with this task:
 
@@ -133,7 +133,7 @@ After, we will run the fuzzer to generate a set of passing and failing inputs. Y
 ```sh
 /lab4/test$ rm -rf fuzz_output && mkdir fuzz_output
 /lab4/test$ timeout 1 ../build/fuzzer ./fuzz2 fuzz_input fuzz_output
-/lab4/test$ ../build/delta ./fuzz2 fuzz_output/failure/input1
+/lab4/test$ delta_debugger ./fuzz2 fuzz_output/failure/input1
 ```
 
 The 1-minimal input should be stored at `fuzz_output/failure/input1.delta`.
@@ -142,7 +142,7 @@ As a specific example consider the string: "abckdanmvelcbaghcajbtkzxmntplwqsraks
 
 ```sh
 /lab4/test$ echo -n "abckdanmvelcbaghcajbtkzxmntplwqsrakstuvbxyz" > tmp
-/lab4/test$ delta-debugger ./fuzz2 tmp
+/lab4/test$ delta_debugger ./fuzz2 tmp
 /lab4/test$ cat tmp.delta
 abckdanmvel
 ```

--- a/_labs/lab04.markdown
+++ b/_labs/lab04.markdown
@@ -10,17 +10,18 @@ synopsis: |
 In this lab, you will build a delta debugger that implements an efficient algorithm for finding a 1-minimal input. You will combine this tool with your fuzzer from previous labs to minimize the random input that the fuzzer finds.
 
 ### Setup
-The skeleton code for Lab 4 is located under `/cis547vm/lab4/`. We will frequently refer to the top-level directory for Lab 4 as `lab4` when describing file locations for the lab.
+The skeleton code for Lab 4 is located under `lab4/`. We will frequently refer to the top-level directory for Lab 4 as `lab4` when describing file locations for the lab. 
+Open the `lab4` directory in VSCode following the Instructions from [Course VM document][course-vm-doc]
 
 The following commands setup the lab:
 
 ```sh
-/cis547vm$ cd lab4
-/cis547vm/lab4$ mkdir build && cd build
-/cis547vm/lab4/build$ cmake ..
-/cis547vm/lab4/build$ make
-/cis547vm/lab4/build$ export
-LD_LIBRARY_PATH=/cis547vm/lab4/build:$LD_LIBRARY_PATH
+/lab4
+/lab4$ mkdir build && cd build
+/lab4/build$ cmake ..
+/lab4/build$ make
+/lab4/build$ export
+LD_LIBRARY_PATH=/lab4/build:$LD_LIBRARY_PATH
 ```
 
 The last `export` command should be run once per terminal session, in order for the correct library path to be set. You should now see delta under `lab4/build/`.
@@ -28,12 +29,12 @@ The last `export` command should be run once per terminal session, in order for 
 The `delta` tool performs delta debugging to shrink a program input. To help generate program runs that pass and fail, you will use your `fuzzer`:
 
 ```sh
-/cis547vm$ cd lab4/test
-/cis547vm/lab4/test$ make
-/cis547vm/lab4/test$ rm -rf fuzz_output && mkdir fuzz_output
-/cis547vm/lab4/test$ timeout 1 ../build/fuzzer ./fuzz0 fuzz_input
+/lab4 cd test
+/lab4/test$ make
+/lab4/test$ rm -rf fuzz_output && mkdir fuzz_output
+/lab4/test$ timeout 1 ../build/fuzzer ./fuzz0 fuzz_input
 fuzz_output
-/cis547vm/lab4/test$ ../build/delta ./fuzz0 fuzz_output/failure/input1
+/lab4/test$ ../build/delta ./fuzz0 fuzz_output/failure/input1
 ```
 
 The last argument (`fuzz_output/failure/input1`) is subject to change depending on what files are available in the `fuzz_output/failure` directory. The reduced input is stored in `fuzz_output/failure/input1.delta`. Additionally, before running another invocation of `../build/delta`, make sure to clean up the `fuzz_output` directory. You can do this by running `rm -rf fuzz_output && mkdir fuzz_output`.
@@ -60,18 +61,18 @@ Overall, you need to modify the 'delta' function to implement the 1-minimal mini
 Your delta debugger should run on any C code that accepts standard input. As we demonstrated in the Setup section, we will compile code to LLVM and instrument the code with the fuzzer pass.
 
 ```sh
-/cis547vm$ cd lab4/test
-/cis547vm/lab4/test$ clang -emit-llvm -S -fno-discard-value-names -c fuzz1.c -g
-/cis547vm/lab4/test$ opt -load ../build/InstrumentPass.so -Instrument -S fuzz1.11 -o fuzz1.instrumented.11
-/cis547vm/lab4/test$ clang -o fuzz1 -L../build -lruntime fuzz1.instrumented.11
+/lab4 cd test
+/lab4/test$ clang -emit-llvm -S -fno-discard-value-names -c fuzz1.c -g
+/lab4/test$ opt -load ../build/InstrumentPass.so -Instrument -S fuzz1.11 -o fuzz1.instrumented.11
+/lab4/test$ clang -o fuzz1 -L../build -lruntime fuzz1.instrumented.11
 ```
 
 After, we will run the fuzzer to generate a set of passing and failing inputs. Your delta debugger should minimize any of the failing input cases.
 
 ```sh
-/cis547vm/lab4/test$ rm -rf fuzz_output && mkdir fuzz_output
-/cis547vm/lab4/test$ timeout 1 ../build/fuzzer ./fuzz2 fuzz_input fuzz_output
-/cis547vm/lab4/test$ ../build/delta ./fuzz2 fuzz_output/failure/input1
+/lab4/test$ rm -rf fuzz_output && mkdir fuzz_output
+/lab4/test$ timeout 1 ../build/fuzzer ./fuzz2 fuzz_input fuzz_output
+/lab4/test$ ../build/delta ./fuzz2 fuzz_output/failure/input1
 ```
 
 The 1-minimal input should be stored at `fuzz_output/failure/input1.delta`.
@@ -79,12 +80,21 @@ The 1-minimal input should be stored at `fuzz_output/failure/input1.delta`.
 As a specific example consider the string: "abckdanmvelcbaghcajbtkzxmntplwqsrakstuvbxyz", which causes `fuzz2` to fail:
 
 ```sh
-/cis547vm/lab4/test$ echo -n "abckdanmvelcbaghcajbtkzxmntplwqsrakstuvbxyz" > tmp
-/cis547vm/lab4/test$ ../build/delta ./fuzz2 tmp
-/cis547vm/lab4/test$ cat tmp.delta
+/lab4/test$ echo -n "abckdanmvelcbaghcajbtkzxmntplwqsrakstuvbxyz" > tmp
+/lab4/test$ ../build/delta ./fuzz2 tmp
+/lab4/test$ cat tmp.delta
 abckdanmvel
 ```
 
 ### Items to Submit
 
-Submit file `Delta.cpp`
+Once you are done with the lab, you can create a `submission.zip` file by using the following command:
+
+```sh
+lab4$ make submit
+...
+submission.zip created successfully.
+```
+Then upload the `submission.zip` file to Gradescope.
+
+[course-vm-doc]: https://cis.upenn.edu/~cis547/vm.doc

--- a/_labs/lab04.markdown
+++ b/_labs/lab04.markdown
@@ -12,7 +12,6 @@ In this lab, you will build a delta debugger that implements an efficient algori
 ### Setup
 The skeleton code for Lab 4 is located under `cis547vm/lab4/`. We will frequently refer to the top-level directory for Lab 4 as `lab4` when describing file locations for the lab. 
 Open the `lab4` directory in VSCode following the Instructions from [Course VM document][course-vm-doc]
-
 The following commands setup the lab:
 
 ```sh
@@ -21,7 +20,7 @@ The following commands setup the lab:
 /lab4/build$ make
 ```
 
-The last `export` command should be run once per terminal session, in order for the correct library path to be set. You should now see delta under `lab4/build/`.
+You should now see delta under `lab4/build/`.
 
 The `delta` tool performs delta debugging to shrink a program input. To help generate program runs that pass and fail, you will use your `fuzzer`:
 

--- a/_labs/lab04.markdown
+++ b/_labs/lab04.markdown
@@ -57,7 +57,7 @@ Overall, you need to modify the 'delta' function to implement the 1-minimal mini
 Your delta debugger should run on any C code that accepts standard input. As we demonstrated in the Setup section, we will compile code to LLVM and instrument the code with the fuzzer pass.
 
 ```sh
-/lab4 cd test
+/lab4$ cd test
 /lab4/test$ clang -emit-llvm -S -fno-discard-value-names -c fuzz1.c -g
 /lab4/test$ opt -load ../build/InstrumentPass.so -Instrument -S fuzz1.11 -o fuzz1.instrumented.11
 /lab4/test$ clang -o fuzz1 -L../build -lruntime fuzz1.instrumented.11

--- a/_labs/lab04.markdown
+++ b/_labs/lab04.markdown
@@ -11,7 +11,7 @@ In this lab, you will build a delta debugger that implements an efficient algori
 
 ### Setup
 The skeleton code for Lab 4 is located under `cis547vm/lab4/`. We will frequently refer to the top-level directory for Lab 4 as `lab4` when describing file locations for the lab. 
-Open the `lab4` directory in VSCode following the Instructions from [Course VM document][course-vm-doc]
+Open the `lab4` directory in VSCode following the Instructions from [Course VM document][course-vm-doc].
 The following commands setup the lab:
 
 ```sh
@@ -25,7 +25,7 @@ You should now see delta under `lab4/build/`.
 The `delta` tool performs delta debugging to shrink a program input. To help generate program runs that pass and fail, you will use your `fuzzer`:
 
 ```sh
-/lab4 cd test
+/lab4$ cd test
 /lab4/test$ make
 /lab4/test$ rm -rf fuzz_output && mkdir fuzz_output
 /lab4/test$ timeout 1 ../build/fuzzer ./fuzz0 fuzz_input

--- a/_labs/lab04.markdown
+++ b/_labs/lab04.markdown
@@ -43,16 +43,16 @@ You will need to edit the `lab4/src/Delta.cpp` file to build a delta debugging t
 
 To perform delta debugging, you will have to repeatedly run the target input with various input strings. The skeleton code provides a couple of auxiliary functions in `lab4/include/Utils.h` to help you with this task:
 
-    - std::string readOneFile(std::string &Path)
-        - Open and read at `Path` and return the content as a single std::string
-    - int runTarget(std::string &Target, std::string &Input)
-        - Run the program (command) `Target`, and pipe `Input` into the running `Target` process. Will return the result of the 'Target' process.
+   - std::string readOneFile(std::string &Path)
+    - Open and read at `Path` and return the content as a single std::string
+   - int runTarget(std::string &Target, std::string &Input)
+    - Run the program (command) `Target`, and pipe `Input` into the running `Target` process. Will return the result of the 'Target' process.
 
 Overall, you need to modify the 'delta' function to implement the 1-minimal minimization algorithm from class. You can break the lab down into subtasks:
 
-    1. Implement the logic to partition the set of changes into delta subsets along with the nabla complement sets.
-    2. Use the `runTarget` function to see which - if any - of the sets cause program failure.
-    3. Repeat (1) and (2) until you have a 1-minimal input.
+   1. Implement the logic to partition the set of changes into delta subsets along with the nabla complement sets.
+   2. Use the `runTarget` function to see which - if any - of the sets cause program failure.
+   3. Repeat (1) and (2) until you have a 1-minimal input.
 
 ### Example Input and Output
 

--- a/_labs/lab04.markdown
+++ b/_labs/lab04.markdown
@@ -10,18 +10,15 @@ synopsis: |
 In this lab, you will build a delta debugger that implements an efficient algorithm for finding a 1-minimal input. You will combine this tool with your fuzzer from previous labs to minimize the random input that the fuzzer finds.
 
 ### Setup
-The skeleton code for Lab 4 is located under `lab4/`. We will frequently refer to the top-level directory for Lab 4 as `lab4` when describing file locations for the lab. 
+The skeleton code for Lab 4 is located under `cis547vm/lab4/`. We will frequently refer to the top-level directory for Lab 4 as `lab4` when describing file locations for the lab. 
 Open the `lab4` directory in VSCode following the Instructions from [Course VM document][course-vm-doc]
 
 The following commands setup the lab:
 
 ```sh
-/lab4
 /lab4$ mkdir build && cd build
 /lab4/build$ cmake ..
 /lab4/build$ make
-/lab4/build$ export
-LD_LIBRARY_PATH=/lab4/build:$LD_LIBRARY_PATH
 ```
 
 The last `export` command should be run once per terminal session, in order for the correct library path to be set. You should now see delta under `lab4/build/`.

--- a/_labs/lab04.markdown
+++ b/_labs/lab04.markdown
@@ -3,11 +3,11 @@ layout: lab
 _id: "4"
 title: "Delta Debugging"
 synopsis: |
-  Building a delta debugger for minimizing input that causes a program to crash.
+  Building a delta debugger for minimizing input that causes a program to crash - this process makes it easier for the user to understand the bug.
 ---
 
 ### Objective
-In this lab, you will build a delta debugger that implements an efficient algorithm for finding a 1-minimal input. You will combine this tool with your fuzzer from previous labs to minimize the random input that the fuzzer finds.
+In this lab, you will build a delta debugger that implements an efficient algorithm for finding a 1-minimal input. You will combine this tool with the fuzzer you wrote in lab3 to minimize the random input that the fuzzer finds.
 
 ### Setup
 The skeleton code for Lab 4 is located under `cis547vm/lab4/`. We will frequently refer to the top-level directory for Lab 4 as `lab4` when describing file locations for the lab. 
@@ -15,21 +15,41 @@ Open the `lab4` directory in VSCode following the Instructions from [Course VM d
 The following commands setup the lab:
 
 ```sh
-/lab4$ mkdir build && cd build
-/lab4/build$ cmake ..
-/lab4/build$ make
+/lab4$ make install
 ```
 
 You should now see delta under `lab4/build/`.
 
-The `delta` tool performs delta debugging to shrink a program input. To help generate program runs that pass and fail, you will use your `fuzzer`:
+The `delta` tool performs delta debugging to shrink a program input. To help generate program runs that pass and fail, you will use your `fuzzer`.
+
+Now to run the `fuzzer` you will need to create the output directory
+where fuzzer will store its results.
 
 ```sh
-/lab4$ cd test
-/lab4/test$ make
-/lab4/test$ rm -rf fuzz_output && mkdir fuzz_output
-/lab4/test$ timeout 1 ../build/fuzzer ./fuzz0 fuzz_input
-fuzz_output
+lab3/test$ mkdir fuzz_output_sanity1
+```
+
+You may recall from lab 1, that AFL could generate new inputs forever and never
+stop running. This is also the case for your fuzzer.
+So for this we will use `timeout` to stop the fuzzer after a specified time.
+
+After this you can run your fuzzer on sanity for 1 second with:
+
+```sh
+lab3/test$ timeout 1s ../build/fuzzer ./fuzz0 fuzz_input fuzz_output_fuzz0
+```
+
+**Note:** the `./` before `fuzz0` is required to let the fuzzer find the executable.
+
+You can also use the Makefile to setup output directory and run the fuzzer for you:
+
+```sh
+lab3/test$ make fuzz-fuzz0
+```
+
+This will run the `fuzzer` on `fuzz0`.
+
+```
 /lab4/test$ ../build/delta ./fuzz0 fuzz_output/failure/input1
 ```
 
@@ -37,19 +57,18 @@ The last argument (`fuzz_output/failure/input1`) is subject to change depending 
 
 ### Lab Instructions
 
-You will need to edit the `lab4/src/Delta.cpp` file to build a delta debugging tool. We have provided a template function - `delta` - for you to implement your minimization logic. `delta` should take a `Target` input program, and an `Input` string that causes the Target program to crash, and find a 1-minimal input that still crashes the input program.
+You will need to edit the `lab4/src/Delta.cpp` file to build a delta debugging tool. We have provided a template function - `delta` - for you to implement your minimization logic. `delta` should take a `Target` input program, and an `Input` bytestring that causes the Target program to crash, and find a 1-minimal input that still crashes the input program.
 
 To perform delta debugging, you will have to repeatedly run the target input with various input strings. The skeleton code provides a couple of auxiliary functions in `lab4/include/Utils.h` to help you with this task:
 
-   - std::string readOneFile(std::string &Path)
-    - Open and read at `Path` and return the content as a single std::string
-   - int runTarget(std::string &Target, std::string &Input)
+
+   - int run_target(Target, Input)
     - Run the program (command) `Target`, and pipe `Input` into the running `Target` process. Will return the result of the 'Target' process.
 
-Overall, you need to modify the 'delta' function to implement the 1-minimal minimization algorithm from class. You can break the lab down into subtasks:
+Overall, you need to modify the `delta_debugger` function to implement the 1-minimal minimization algorithm from class. You can break the lab down into subtasks:
 
    1. Implement the logic to partition the set of changes into delta subsets along with the nabla complement sets.
-   2. Use the `runTarget` function to see which - if any - of the sets cause program failure.
+   2. Use the `run_target` function to see which - if any - of the sets cause program failure.
    3. Repeat (1) and (2) until you have a 1-minimal input.
 
 ### Example Input and Output
@@ -77,7 +96,7 @@ As a specific example consider the string: "abckdanmvelcbaghcajbtkzxmntplwqsraks
 
 ```sh
 /lab4/test$ echo -n "abckdanmvelcbaghcajbtkzxmntplwqsrakstuvbxyz" > tmp
-/lab4/test$ ../build/delta ./fuzz2 tmp
+/lab4/test$ delta-debugger ./fuzz2 tmp
 /lab4/test$ cat tmp.delta
 abckdanmvel
 ```

--- a/_labs/lab04.markdown
+++ b/_labs/lab04.markdown
@@ -45,14 +45,14 @@ To build and install the package, run:
 Unlike with `c++`, you *won't* need to re-run this command
 after making changes to your code.
 Further, you will be able to use your delta debugger using the
-`delta_debugger` command from the terminal.
+`delta-debugger` command from the terminal.
 
-The `delta_debugger` tool performs delta debugging to shrink
+The `delta-debugger` tool performs delta debugging to shrink
 a crashing input to a program.
 
 ##### Step 2.
 
-To use `delta_debugger` with a program you first need to find some input
+To use `delta-debugger` with a program you first need to find some input
 that will crash the program.
 To find such an input we will use a fuzzer.
 
@@ -92,14 +92,14 @@ fuzz_output_sanity1
     └── inputN
 ```
 
-You can now use `delta_debugger` to minimize the crashing
+You can now use `delta-debugger` to minimize the crashing
 inputs found by the fuzzer.
 
 ```
 /lab4/test$ delta-debugger ./sanity1 fuzz_output_sanity1/failure/input1
 ```
 
-The last argument (`fuzz_output/failure/input1`) is subject to change depending on what files are available in the `fuzz_output/failure` directory. The reduced input is stored in `fuzz_output/failure/input1.delta`. Additionally, before running another invocation of `delta_debugger`, make sure to clean up the `fuzz_output` directory. You can do this by running `rm -rf fuzz_output && mkdir fuzz_output`.
+The last argument (`fuzz_output/failure/input1`) is subject to change depending on what files are available in the `fuzz_output/failure` directory. The reduced input is stored in `fuzz_output/failure/input1.delta`. Additionally, before running another invocation of `delta-debugger`, make sure to clean up the `fuzz_output` directory. You can do this by running `rm -rf fuzz_output && mkdir fuzz_output`.
 
 ### Lab Instructions
 
@@ -111,7 +111,7 @@ To perform delta debugging, you will have to repeatedly run the target input wit
    - int run_target(Target, Input)
     - Run the program (command) `Target`, and pipe `Input` into the running `Target` process. Will return the result of the 'Target' process.
 
-Overall, you need to modify the `delta_debugger` function to implement the 1-minimal minimization algorithm from class. You can break the lab down into subtasks:
+Overall, you need to modify the `delta-debugger` function to implement the 1-minimal minimization algorithm from class. You can break the lab down into subtasks:
 
    1. Implement the logic to partition the set of changes into delta subsets along with the nabla complement sets.
    2. Use the `run_target` function to see which - if any - of the sets cause program failure.
@@ -133,7 +133,7 @@ After, we will run the fuzzer to generate a set of passing and failing inputs. Y
 ```sh
 /lab4/test$ rm -rf fuzz_output && mkdir fuzz_output
 /lab4/test$ timeout 1 ../build/fuzzer ./fuzz2 fuzz_input fuzz_output
-/lab4/test$ delta_debugger ./fuzz2 fuzz_output/failure/input1
+/lab4/test$ delta-debugger ./fuzz2 fuzz_output/failure/input1
 ```
 
 The 1-minimal input should be stored at `fuzz_output/failure/input1.delta`.
@@ -142,7 +142,7 @@ As a specific example consider the string: "abckdanmvelcbaghcajbtkzxmntplwqsraks
 
 ```sh
 /lab4/test$ echo -n "abckdanmvelcbaghcajbtkzxmntplwqsrakstuvbxyz" > tmp
-/lab4/test$ delta_debugger ./fuzz2 tmp
+/lab4/test$ delta-debugger ./fuzz2 tmp
 /lab4/test$ cat tmp.delta
 abckdanmvel
 ```

--- a/_labs/lab04.markdown
+++ b/_labs/lab04.markdown
@@ -1,10 +1,89 @@
 ---
 layout: lab
 _id: "4"
-title: "Delta"
+title: "Delta Debugging"
 synopsis: |
-  Building a coverage-guided random input generator a.k.a. “fuzzer” for testing C programs.
+  Building a delta debugger for minimizing input that causes a program to crash.
 ---
 
 ### Objective
-Foo-bar
+In this lab, you will build a delta debugger that implements an efficient algorithm for finding a 1-minimal input. You will combine this tool with your fuzzer from previous labs to minimize the random input that the fuzzer finds.
+
+### Setup
+The skeleton code for Lab 4 is located under `/cis547vm/lab4/`. We will frequently refer to the top-level directory for Lab 4 as `lab4` when describing file locations for the lab.
+
+The following commands setup the lab:
+
+```sh
+/cis547vm$ cd lab4
+/cis547vm/lab4$ mkdir build && cd build
+/cis547vm/lab4/build$ cmake ..
+/cis547vm/lab4/build$ make
+/cis547vm/lab4/build$ export
+LD_LIBRARY_PATH=/cis547vm/lab4/build:$LD_LIBRARY_PATH
+```
+
+The last `export` command should be run once per terminal session, in order for the correct library path to be set. You should now see delta under `lab4/build/`.
+
+The `delta` tool performs delta debugging to shrink a program input. To help generate program runs that pass and fail, you will use your `fuzzer`:
+
+```sh
+/cis547vm$ cd lab4/test
+/cis547vm/lab4/test$ make
+/cis547vm/lab4/test$ rm -rf fuzz_output && mkdir fuzz_output
+/cis547vm/lab4/test$ timeout 1 ../build/fuzzer ./fuzz0 fuzz_input
+fuzz_output
+```
+
+The last argument (`fuzz_output/failure/input1`) is subject to change depending on what files are available in the `fuzz_output/failure` directory. The reduced input is stored in `fuzz_output/failure/input1.delta`. Additionally, before running another invocation of `../build/delta`, make sure to clean up the `fuzz_output` directory. You can do this by running `rm -rf fuzz_putput && mkdir fuzz_output`.
+
+### Lab Instructions
+
+You will need to edit the `lab4/src/Delta.cpp` file to build a delta debugging tool. We have provided a template function - `delta` - for you to implement your minimization logic. `delta` should take a `Target` input program, and an `Input` string that causes the Target program to crash, and find a 1-minimal input that still crashes the input program.
+
+To perform delta debugging, you will have to repeatedly run the target input with various input strings. The skeleton code provides a couple of auxiliary functions in `lab4/include/Utils.h` to help you with this task:
+
+    - std::string readOneFile(std::string &Path)
+        - Open and read at `Path` and return the content as a single std::string
+    - int runTarget(std::string &Target, std::string &Input)
+        - Run the program (command) `Target`, and pipe `Input` into the running `Target` process. Will return the result of the 'Target' process.
+
+Overall, you need to modify the 'delta' function to implement the 1-minimal minimization algorithm from class. You can break the lab down into subtasks:
+
+    1. Implement the logic to partition the set of changes into delta subsets along with the nabla complement sets.
+    2. Use the `runTarget` function to see which - if any - of the sets cause program failure.
+    3. Repeat (1) and (2) until you have a 1-minimal input.
+
+### Example Input and Output
+
+Your delta debugger should run on any C code that accepts standard input. As we demonstrated in the Setup section, we will compile code to LLVM and instrument the code with the fuzzer pass.
+
+```sh
+/cis547vm$ cd lab4/test
+/cis547vm/lab4/test$ clang -emit-llvm -S -fno-discard-value-names -c fuzz1.c -g
+/cis547vm/lab4/test$ opt -load ../build/InstrumentPass.so -Instrument -S fuzz1.11 -o fuzz1.instrumented.11
+/cis547vm/lab4/test$ clang -o fuzz1 -L../build -lruntime fuzz1.instrumented.11
+```
+
+After, we will run the fuzzer to generate a set of passing and failing inputs. Your delta debugger should minimize any of the failing input cases.
+
+```sh
+/cis547vm/lab4/test$ rm -rf fuzz_output && mkdir fuzz_output
+/cis547vm/lab4/test$ timeout 1 ../build/fuzzer ./fuzz2 fuzz_input fuzz_output
+/cis547vm/lab4/test$ ../build/delta ./fuzz2 fuzz_output/failure/input1
+```
+
+The 1-minimal input should be stored at `fuzz_output/failure/input1.delta`.
+
+As a specific example consider the string: "abckdanmvelcbaghcajbtkzxmntplwqsrakstuvbxyz", which causes `fuzz2` to fail:
+
+```sh
+/cis547vm/lab4/test$ echo -n "abckdanmvelcbaghcajbtkzxmntplwqsrakstuvbxyz" > tmp
+/cis547vm/lab4/test$ ../build/delta ./fuzz2 tmp
+/cis547vm/lab4/test$ cat tmp.delta
+abckdanmvel
+```
+
+### Items to Submit
+
+Submit file `Delta.cpp`


### PR DESCRIPTION
- Initializing Lab04 Document
- Wrote lab04.
- fixed the comment block lines.
- Corrected errors shown to me by Shodhan
- Removed Devcontainer Line
- Added cis547vm/lab4/ in the Setup
- Removed sentence about export command
- Forgot the money
- Another Dollar Sign Added
- Some of the changes about which Harsh and I spoke.
- Make an edit pass on first half of lab4 document.
- Made slight modifications: changed .ccp to .py
- delta_debugger to delta-debugger (where appropriate)
- Edit the second half of lab4 document.
